### PR TITLE
ajout de greenet

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Cette page a pour modeste ambition de lister les ressources et l'écosystème su
 * [Fairphone](https://www.fairphone.com/fr/), smartphone éthique et réparable.
 * [Frédéric Bordage de GreenIT.fr](https://www.greenit.fr/), consultant et formateur numérique responsable et éco-conception de services numériques.
 * [Greenspector](https://greenspector.com/), outil de mesure de l’empreinte environnementale des applications.
+* [Greenet.io](https://www.greenet.io/), application de mesure et réduciton de l’empreinte carbone de votre navigation web.
 
 ## Ressources
 
@@ -98,6 +99,7 @@ Cette page a pour modeste ambition de lister les ressources et l'écosystème su
 * [Mobile Efficiency Index](https://mobile-efficiency-index.com/)
 * [Axe Developer Tools](https://addons.mozilla.org/fr/firefox/addon/axe-devtools/), accessibility auditing to the Firefox Developer Tools
 * [Carbonalyser](https://theshiftproject.org/carbonalyser-extension-navigateur/)
+* [Greenet.io](https://www.greenet.io/)
 * [Argos](https://github.com/marmelab/argos), docker monitoring experiment
 
 ## Financements


### PR DESCRIPTION
Ajout de greenet.io dans la liste des acteurs privés pour mesurer et réduire l'empreinte du web